### PR TITLE
mobile navbar fixed

### DIFF
--- a/src/components/MobileNavBar.js
+++ b/src/components/MobileNavBar.js
@@ -6,7 +6,7 @@ import { faBars, faSearch } from '@fortawesome/free-solid-svg-icons';
 
 const customStyles = {
   content: {
-    top: '25%',
+    top: '35%',
     left: '50%',
     right: 'auto',
     bottom: 'auto',

--- a/src/index.css
+++ b/src/index.css
@@ -63,7 +63,6 @@
   height: 50px;
   background: #97bf0f;
   opacity: 0.8;
-  z-index: 1;
 }
 
 .clearfix {
@@ -116,6 +115,10 @@
   }
 
   .mobile_menu_background {
+    display: none;
+  }
+
+  .ReactModalPortal {
     display: none;
   }
 


### PR DESCRIPTION
@Baroka-wp , @kwambiee , I have fixed the mobile navbar. The modal is now disappearing on the desktop version, and the close button can be seen on all mobile sizes.