### PR TITLE
fix-booking-link-bug

### DIFF
--- a/src/components/CarrouselCard.js
+++ b/src/components/CarrouselCard.js
@@ -6,7 +6,7 @@ import { faLocationDot } from '@fortawesome/free-solid-svg-icons';
 import PropTypes from 'prop-types';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
-import Link from '@mui/material/Link';
+import { Link } from 'react-router-dom';
 import Socials from './socials';
 import './pages/mainpage.css';
 


### PR DESCRIPTION
## yatch-house-front-end: fix-booking-link-bug

In this Pull Request I fixed the bug on the link that leads to the booking board by:
- Changing  Link's source to `react-router-dom`

![Screenshot from 2022-09-27 19-37-43](https://user-images.githubusercontent.com/97834160/192598951-abdf24af-7532-4cbc-8a3a-3e89f36f9cfc.png)
